### PR TITLE
driver exoscale: clarify the image template name. [wip]

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -2049,8 +2049,6 @@ manuals:
           title: backup
         - path: /datacenter/dtr/2.4/reference/cli/destroy/
           title: destroy
-        - path: /datacenter/dtr/2.4/reference/cli/dumpcerts/
-          title: dumpcerts
         - path: /datacenter/dtr/2.4/reference/cli/images/
           title: images
         - path: /datacenter/dtr/2.4/reference/cli/install/

--- a/datacenter/dtr/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.2/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -69,6 +69,10 @@ tool launches an interactive prompt where you can run RethinkDB
 queries such as:
 
 ```none
+# List problems detected within the rethinkdb cluster
+> r.db("rethinkdb").table("current_issues")
+...
+
 # List all the DBs in RethinkDB
 > r.dbList()
 [ 'dtr2',
@@ -95,10 +99,6 @@ queries such as:
     namespaceAccountID: '924bf131-6213-43fa-a5ed-d73c7ccf392e',
     pk: 'cf5e8bf1197e281c747f27e203e42e22721d5c0870b06dfb1060ad0970e99ada',
     visibility: 'public' },
-...
-
-# List problems detected within the rethinkdb cluster
-> r.db("rethinkdb").table("current_issues")
 ...
 ```
 

--- a/datacenter/dtr/2.3/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.3/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -69,6 +69,10 @@ tool launches an interactive prompt where you can run RethinkDB
 queries such as:
 
 ```none
+# List problems detected within the rethinkdb cluster
+> r.db("rethinkdb").table("current_issues")
+...
+
 # List all the DBs in RethinkDB
 > r.dbList()
 [ 'dtr2',
@@ -95,10 +99,6 @@ queries such as:
     namespaceAccountID: '924bf131-6213-43fa-a5ed-d73c7ccf392e',
     pk: 'cf5e8bf1197e281c747f27e203e42e22721d5c0870b06dfb1060ad0970e99ada',
     visibility: 'public' },
-...
-
-# List problems detected within the rethinkdb cluster
-> r.db("rethinkdb").table("current_issues")
 ...
 ```
 

--- a/datacenter/dtr/2.4/guides/admin/install/system-requirements.md
+++ b/datacenter/dtr/2.4/guides/admin/install/system-requirements.md
@@ -38,7 +38,7 @@ Docker Enterprise Edition is a software subscription that includes three product
 
 ## Hardware requirements
 
-Hardware requirements for DTR nodes are found at [UCP Hardware requirement](https://docs.docker.com/datacenter/ucp/2.2/guides/admin/install/system-requirements/) 
+Hardware requirements for DTR nodes are found at [UCP Hardware requirement](/datacenter/ucp/2.2/guides/admin/install/system-requirements.md) 
 
 ## Where to go next
 

--- a/datacenter/dtr/2.4/guides/admin/install/system-requirements.md
+++ b/datacenter/dtr/2.4/guides/admin/install/system-requirements.md
@@ -36,6 +36,10 @@ Docker Enterprise Edition is a software subscription that includes three product
 
 [Learn more about the maintenance lifecycle for these products](http://success.docker.com/Get_Help/Compatibility_Matrix_and_Maintenance_Lifecycle).
 
+## Hardware requirements
+
+Hardware requirements for DTR nodes are found at [UCP Hardware requirement](https://docs.docker.com/datacenter/ucp/2.2/guides/admin/install/system-requirements/) 
+
 ## Where to go next
 
 * [DTR architecture](../../architecture.md)

--- a/datacenter/dtr/2.4/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
+++ b/datacenter/dtr/2.4/guides/admin/monitor-and-troubleshoot/troubleshoot-with-logs.md
@@ -69,6 +69,10 @@ tool launches an interactive prompt where you can run RethinkDB
 queries such as:
 
 ```none
+# List problems detected within the rethinkdb cluster
+> r.db("rethinkdb").table("current_issues")
+...
+
 # List all the DBs in RethinkDB
 > r.dbList()
 [ 'dtr2',
@@ -95,10 +99,6 @@ queries such as:
     namespaceAccountID: '924bf131-6213-43fa-a5ed-d73c7ccf392e',
     pk: 'cf5e8bf1197e281c747f27e203e42e22721d5c0870b06dfb1060ad0970e99ada',
     visibility: 'public' },
-...
-
-# List problems detected within the rethinkdb cluster
-> r.db("rethinkdb").table("current_issues")
 ...
 ```
 

--- a/datacenter/dtr/2.4/reference/cli/index.md
+++ b/datacenter/dtr/2.4/reference/cli/index.md
@@ -32,6 +32,4 @@ docker run -it --rm docker/dtr \
 |[restore](restore)| Install and restore DTR from an existing backup                 |
 |[backup](backup)| Create a backup of DTR                 |
 |[upgrade](upgrade)| Upgrade DTR 2.3.x cluster to this version                 |
-|[dumpcerts](dumpcerts)| Print the TLS certificates used by DTR                 |
 |[images](images)| List all the images necessary to install DTR                 |
-

--- a/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
+++ b/datacenter/ucp/2.2/guides/user/services/use-domain-names-to-access-services.md
@@ -135,13 +135,13 @@ com.docker.ucp.mesh.http.2=<key-1>=<value-1>
 The keys and values in your label are what defined the route configuration.
 These keys are supported:
 
-| Key                   | Mandatory                                                | Values                                                            | Description                                                                                              |
-|:----------------------|:---------------------------------------------------------|:------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------|
-| external_route        | yes                                                      | http://domain-name, http://domain-name/path, or sni://domain-name | The external URL to route to this service                                                                |
-| internal_port         | yes, if the service publishes no ports or multiple ports | port-number                                                       | The internal port to use for the service                                                                 |
-| sticky_sessions       | no                                                       | cookie-name                                                       | Always route a user to the same service, using HTTP cookies. This option can't be used with HTTPS routes |
-| redirect              | no                                                       | http://domain-name, or sni://domain-name                          | Redirect incoming requests to another route using an HTTP 301 redirect                                   |
-| include_forwarded_for | no                                                       | true                                                              | If present, include the X-Forwarded-For header in requests                                               |
+| Key                   | Mandatory                                                | Values                                   | Description                                                                                              |
+|:----------------------|:---------------------------------------------------------|:-----------------------------------------|:---------------------------------------------------------------------------------------------------------|
+| external_route        | yes                                                      | http://domain-name, or sni://domain-name | The external URL to route to this service                                                                |
+| internal_port         | yes, if the service publishes no ports or multiple ports | port-number                              | The internal port to use for the service                                                                 |
+| sticky_sessions       | no                                                       | cookie-name                              | Always route a user to the same service, using HTTP cookies. This option can't be used with HTTPS routes |
+| redirect              | no                                                       | http://domain-name, or sni://domain-name | Redirect incoming requests to another route using an HTTP 301 redirect                                   |
+| include_forwarded_for | no                                                       | true                                     | If present, include the X-Forwarded-For header in requests                                               |
 
 
 ### Sticky sessions

--- a/get-started/part4.md
+++ b/get-started/part4.md
@@ -224,7 +224,7 @@ like `myvm1` execute Docker commands; workers are just for capacity.
 
 ### Configure a `docker-machine` shell to the swarm manager
 
-So far, you've been wrapping Docker commmands in `docker-machine ssh` to talk to
+So far, you've been wrapping Docker commands in `docker-machine ssh` to talk to
 the VMs. Another option is to run `docker-machine env <machine>` to get
 and run a command that configures your current shell to talk to the Docker
 daemon on the VM. This method works better for the next step because it allows

--- a/machine/drivers/exoscale.md
+++ b/machine/drivers/exoscale.md
@@ -10,25 +10,24 @@ Get your API key and API secret key from [API details](https://portal.exoscale.c
 
 ## Usage
 
-    $ docker-machine create --driver exoscale --exoscale-api-key=API --exoscale-api-secret-key=SECRET vm
+    $ docker-machine create --driver exoscale \
+        --exoscale-api-key=API \
+        --exoscale-api-secret-key=SECRET \
+        vm
 
 ## Options
 
--   `--exoscale-url`: Your API endpoint.
--   `--exoscale-api-key`: **required** Your API key.
--   `--exoscale-api-secret-key`: **required** Your API secret key.
--   `--exoscale-instance-profile`: Instance profile.
--   `--exoscale-disk-size`: Disk size for the host in GB (10, 50, 100, 200, 400).
--   `--exoscale-image`: Image template (e.g. ubuntu-16.04, ubuntu-15.10).
--   `--exoscale-security-group`: Security group. It will be created if it doesn't exist.
--   `--exoscale-availability-zone`: Exoscale availability zone.
--   `--exoscale-ssh-user`: SSH username, which must match the default SSH user for the used image.
--   `--exoscale-userdata`: Path to file containing user data for cloud-init.
--   `--exoscale-affinity-group`: Affinity group the machine will be started in.
-
-If a custom security group is provided, you need to ensure that you allow TCP ports 22 and 2376 in an ingress rule. Moreover, if you want to use Swarm, also add TCP port 3376.
-
-There is a limit to the number of docker machines that an anti-affinity group can have.  This can be worked around by specifying an additional anti-affinity group using `--exoscale-affinity-group=docker-machineX`
+-   `--exoscale-url`: Your API endpoint;
+-   `--exoscale-api-key`: **required** Your API key;
+-   `--exoscale-api-secret-key`: **required** Your API secret key;
+-   `--exoscale-instance-profile`: Instance profile (Small, Medium, Large, ...);
+-   `--exoscale-disk-size`: Disk size for the host in GB (10, 50, 100, 200, 400);
+-   `--exoscale-image`: Image template (e.g. `Linux Ubuntu 16.04 LTS 64-bit` also known as `ubuntu-16.04`, [see below](#image-template-name));
+-   `--exoscale-security-group`: Security group. _It will be created if it doesn't exist_;
+-   `--exoscale-availability-zone`: Exoscale [availability zone][datacenters] (CH-DK-2, AT-VIE-1, DE-FRA-1, ...);
+-   `--exoscale-ssh-user`: SSH username (e.g. `ubuntu`, [see below](#ssh-username));
+-   `--exoscale-userdata`: Path to file containing user data for [cloud-init](https://cloud-init.io/);
+-   `--exoscale-affinity-group`: [Anti-affinity group][anti-affinity] the machine will be started in.
 
 ### Environment variables and default values
 
@@ -39,9 +38,50 @@ There is a limit to the number of docker machines that an anti-affinity group ca
 | **`--exoscale-api-secret-key`** | `EXOSCALE_API_SECRET`        | -                                 |
 | `--exoscale-instance-profile`   | `EXOSCALE_INSTANCE_PROFILE`  | `small`                           |
 | `--exoscale-disk-size`          | `EXOSCALE_DISK_SIZE`         | `50`                              |
-| `--exoscale-image`              | `EXOSCALE_IMAGE`             | `ubuntu-16.04`                    |
+| `--exoscale-image`              | `EXOSCALE_IMAGE`             | `Linux Ubuntu 16.04 LTS 64-bit`   |
 | `--exoscale-security-group`     | `EXOSCALE_SECURITY_GROUP`    | `docker-machine`                  |
 | `--exoscale-availability-zone`  | `EXOSCALE_AVAILABILITY_ZONE` | `ch-dk-2`                         |
-| `--exoscale-ssh-user`           | `EXOSCALE_SSH_USER`          | `ubuntu`                          |
+| `--exoscale-ssh-user`           | `EXOSCALE_SSH_USER`          | -                                 |
 | `--exoscale-userdata`           | `EXOSCALE_USERDATA`          | -                                 |
 | `--exoscale-affinity-group`     | `EXOSCALE_AFFINITY_GROUP`    | -                                 |
+
+**NB:** the _instance profile_, _image_, and _availability zone_ are case insensitive.
+
+### Image template name
+
+The [VM templates][templates] available at Exoscale are listed on the Portal when adding a new instance.
+
+For any Linux template, you may use the shorter name composed only of the name and version. E.g.
+
+| Full name                       | Short name           |
+| ------------------------------- | -------------------- |
+| Linux Debian 8 64-bit           | `debian-8`           |
+| Linux Ubuntu 16.04 LTS 64-bit   | `ubuntu-16.04`       |
+| Linux CentOS 7.3 64-bit         | `centos-7.3`         |
+| Linux CoreOS stable 1298 64-bit | `coreos-stable-1298` |
+
+**NB:** Docker won't work for non-Linux machines like OpenBSD and Windows Server.
+
+### SSH Username
+
+The exoscale driver does a wild guess to match the default SSH user. If left empty, it picks a suitable one:
+
+- `centos` for Centos 7.3+;
+- `core` for Linux CoreOS;
+- `debian` for Debian 8+;
+- `ubuntu` for Ubuntu;
+- otherwise, `root`.
+
+### Custom security group
+
+If a custom security group is provided, you need to ensure that you allow TCP ports 22 and 2376 in an ingress rule.
+
+Moreover, if you want to use [Docker Swarm](/engine/swarm/swarm-tutorial/), also add TCP port 2377.
+
+### More than 8 docker machines?
+
+There is a limit to the number of machines that an anti-affinity group can have.  This can be worked around by specifying an additional anti-affinity group using `--exoscale-affinity-group=docker-machineX`
+
+[templates]: https://www.exoscale.ch/open-cloud/templates/
+[datacenters]: https://www.exoscale.ch/infrastructure/datacenters/
+[anti-affinity]: https://community.exoscale.ch/documentation/compute/anti-affinity-groups/


### PR DESCRIPTION
a dry-run PR to double check before sending it over.

### Proposed changes

It clarifies some aspects of the docker-machine exoscale driver usage. It wasn't super easy to guess the image name from the ones displayed in the UI.

### Related issues (optional)

TODO: open PR on docker/machine with the updated egoscale repo.